### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server for scanning AI-related dotfiles and configuration files, and expose them to the agent tool.
 
+<a href="https://glama.ai/mcp/servers/@druellan/llmdotfiles-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@druellan/llmdotfiles-mcp/badge" alt="LLMDotfiles Server MCP server" />
+</a>
+
 ## Overview
 
 This MCP server provides access to a variety of dotfiles and configuration resources that help LLMs understand project context and guidelines.


### PR DESCRIPTION
This PR adds a badge for the [LLMDotfiles MCP Server](https://glama.ai/mcp/servers/@druellan/llmdotfiles-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@druellan/llmdotfiles-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@druellan/llmdotfiles-mcp/badge" alt="LLMDotfiles Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.